### PR TITLE
If username wasn't edited in form, use current username from store

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -138,7 +138,7 @@ class EditProfile extends React.Component {
         }).then(() => {
           Swal({
             type: 'success',
-            title: `You've successfully updated your profile ${username}!`,
+            title: `You've successfully updated your profile ${username || user.username}!`,
           })
             .then(() => {
               resetUpdateForm();


### PR DESCRIPTION
Swal update confirmation shows blank username if not updating username, because it grabs the value from the form/state.